### PR TITLE
add authorization block for conversation route definition

### DIFF
--- a/claude-ai/amplify/data/resource.ts
+++ b/claude-ai/amplify/data/resource.ts
@@ -4,7 +4,8 @@ const schema = a.schema({
   chat: a.conversation({
     aiModel: a.ai.model("Claude 3.5 Sonnet"),
     systemPrompt: `You are a helpful assistant`,
-  }),
+  })
+    .authorization((allow) => allow.owner()),
 
   chatNamer: a
     .generation({


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- adds `.authorization((allow) => allow.owner())` to conversation route schema definition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
