### PR TITLE
fix: rename icon from LuMoreVertical to LuMoveVertical

### DIFF
--- a/claude-ai/src/components/Sidebar/ConversationItem.tsx
+++ b/claude-ai/src/components/Sidebar/ConversationItem.tsx
@@ -11,7 +11,7 @@ import {
 } from "@aws-amplify/ui-react";
 import {
   LuCheck,
-  LuMoreVertical,
+  LuMoveVertical,
   LuPencil,
   LuTrash2,
   LuX,
@@ -85,7 +85,7 @@ export const ConversationItem = ({
         size="small"
         trigger={
           <MenuButton size="small">
-            <LuMoreVertical />
+            <LuMoveVertical />
           </MenuButton>
         }
       >

--- a/claude-ai/src/components/Sidebar/ConversationItem.tsx
+++ b/claude-ai/src/components/Sidebar/ConversationItem.tsx
@@ -11,7 +11,7 @@ import {
 } from "@aws-amplify/ui-react";
 import {
   LuCheck,
-  LuMoveVertical,
+  LuEllipsisVertical,
   LuPencil,
   LuTrash2,
   LuX,
@@ -85,7 +85,7 @@ export const ConversationItem = ({
         size="small"
         trigger={
           <MenuButton size="small">
-            <LuMoveVertical />
+            <LuEllipsisVertical />
           </MenuButton>
         }
       >


### PR DESCRIPTION
The React Icons name was incorrect and caused an error, so I've changed it to the correct one.
This update ensures the right icon is displayed and resolves the runtime issue.