### PR TITLE
fix: rename icon from LuMoreVertical to LuEllipsisVertical

### DIFF
--- a/claude-ai/src/components/Sidebar/ConversationItem.tsx
+++ b/claude-ai/src/components/Sidebar/ConversationItem.tsx
@@ -11,7 +11,7 @@ import {
 } from "@aws-amplify/ui-react";
 import {
   LuCheck,
-  LuMoreVertical,
+  LuMoveVertical,
   LuPencil,
   LuTrash2,
   LuX,
@@ -85,7 +85,7 @@ export const ConversationItem = ({
         size="small"
         trigger={
           <MenuButton size="small">
-            <LuMoreVertical />
+            <LuMoveVertical />
           </MenuButton>
         }
       >

--- a/claude-ai/src/components/Sidebar/ConversationItem.tsx
+++ b/claude-ai/src/components/Sidebar/ConversationItem.tsx
@@ -11,7 +11,7 @@ import {
 } from "@aws-amplify/ui-react";
 import {
   LuCheck,
-  LuMoveVertical,
+  LuEllipsisVertical,
   LuPencil,
   LuTrash2,
   LuX,
@@ -85,7 +85,7 @@ export const ConversationItem = ({
         size="small"
         trigger={
           <MenuButton size="small">
-            <LuMoveVertical />
+            <LuEllipsisVertical />
           </MenuButton>
         }
       >


### PR DESCRIPTION
The icon name was changed upstream, causing errors. This commit updates the code to reflect the new icon name.

Reference:
https://github.com/lucide-icons/lucide/commits/main/icons/ellipsis-vertical.svg

Close Pull request
https://github.com/aws-samples/amplify-ai-examples/pull/12
This pull request was closed because the change was based on a misunderstanding of the icon name.

