### PR TITLE
Resolve Gitbub issue #17

### DIFF
--- a/claude-ai/src/app/chat/[id]/Chat.tsx
+++ b/claude-ai/src/app/chat/[id]/Chat.tsx
@@ -1,6 +1,9 @@
 "use client";
 import * as React from "react";
-import { AIConversation } from "@aws-amplify/ui-react-ai";
+import { 
+  AIConversation, 
+  type SendMesageParameters 
+} from "@aws-amplify/ui-react-ai";
 import { View } from "@aws-amplify/ui-react";
 import { client, useAIConversation } from "@/client";
 import { ConversationsContext } from "@/providers/ConversationsProvider";
@@ -8,6 +11,7 @@ import ReactMarkdown from "react-markdown";
 
 export const Chat = ({ id }: { id: string }) => {
   const { updateConversation } = React.useContext(ConversationsContext);
+  const [initialMessageProcessed, setInitialMessageProcessed] = React.useState(false);
   const [
     {
       data: { messages, conversation },
@@ -16,27 +20,65 @@ export const Chat = ({ id }: { id: string }) => {
     sendMessage,
   ] = useAIConversation("chat", { id });
 
+  // Send initial message when component mounts
+  React.useEffect(() => {
+    const initialMessageKey = `initial_message_${id}`;
+    const storedMessage = sessionStorage.getItem(initialMessageKey);
+
+    if (storedMessage && conversation && !initialMessageProcessed && messages.length === 0) {
+      const message = JSON.parse(storedMessage) as SendMesageParameters;
+      sendMessage(message);
+      setInitialMessageProcessed(true);
+      sessionStorage.removeItem(initialMessageKey);
+
+      // Generate chat name
+      if (!conversation.name) {
+        client.generations
+          .chatNamer({
+            content: message.content.map((content) => 
+              'text' in content ? content.text ?? "" : ""
+            ).join(""),
+          })
+          .then((res) => {
+            if (res.data?.name) {
+              updateConversation({
+                id,
+                name: res.data.name,
+              });
+            }
+          });
+      }
+    }
+  }, [id, conversation, messages.length, sendMessage, updateConversation, initialMessageProcessed]);
+
+  const handleNewMessage = (message: SendMesageParameters) => {
+    sendMessage(message);
+    
+    // Generate name for first user message if not already named
+    if (!conversation?.name && messages.length === 0) {
+      client.generations
+        .chatNamer({
+          content: message.content.map((content) => 
+            'text' in content ? content.text ?? "" : ""
+          ).join(""),
+        })
+        .then((res) => {
+          if (res.data?.name) {
+            updateConversation({
+              id,
+              name: res.data.name,
+            });
+          }
+        });
+    }
+  };
+
   return (
     <View padding="large" flex="1">
       <AIConversation
         allowAttachments
         messages={messages}
-        handleSendMessage={(message) => {
-          sendMessage(message);
-          // only run this on the first message...
-          if (!conversation?.name) {
-            client.generations
-              .chatNamer({
-                content: message.content.map((c) => c.text ?? "").join(""),
-              })
-              .then((res) => {
-                updateConversation({
-                  id,
-                  name: res.data?.name ?? "",
-                });
-              });
-          }
-        }}
+        handleSendMessage={handleNewMessage}
         isLoading={isLoading}
         messageRenderer={{
           text: ({ text }) => <ReactMarkdown>{text}</ReactMarkdown>,

--- a/claude-ai/src/app/page.tsx
+++ b/claude-ai/src/app/page.tsx
@@ -2,38 +2,44 @@
 
 import * as React from "react";
 import { ConversationsContext } from "@/providers/ConversationsProvider";
-import { Button, Flex, TextAreaField } from "@aws-amplify/ui-react";
+import { View } from "@aws-amplify/ui-react";
+import { AIConversation } from "@aws-amplify/ui-react-ai";
 import { useRouter } from "next/navigation";
 
 export default function Home() {
   const { createConversation } = React.useContext(ConversationsContext);
   const router = useRouter();
-  // we would need to use a plain textarea field
-  // on submit we would need to:
-  // 1. create a conversation
-  // 2. after creation, we need to update the URL
-  // and send the first message to the conversation
-  // then load the conversation
+  const [isNavigating, setIsNavigating] = React.useState(false);
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const data = new FormData(e.currentTarget);
-    const prompt = data.get("message") as string;
-    console.log(prompt);
-    createConversation().then((conversation) => {
-      if (!conversation) return;
-      router.push(`/chat/${conversation.id}`);
-      conversation?.sendMessage({ content: [{ text: prompt }] });
-    });
+  const handleSendMessage = async (message: { content: { text?: string }[] }) => {
+    if (isNavigating) return;
+    setIsNavigating(true);
+    
+    try {
+      const conversation = await createConversation();
+      if (!conversation) {
+        setIsNavigating(false);
+        return;
+      }
+      
+      // Store initial message in sessionStorage for the chat page
+      sessionStorage.setItem(`initial_message_${conversation.id}`, JSON.stringify(message));
+      
+      // Navigate to chat page
+      await router.push(`/chat/${conversation.id}`);
+    } catch (error) {
+      console.error('Error creating conversation:', error);
+      setIsNavigating(false);
+    }
   };
 
   return (
-    <Flex direction="column">
-      <h1>Hello, Amplify 👋</h1>
-      <Flex as="form" onSubmit={handleSubmit}>
-        <TextAreaField name="message" autoResize label="message" labelHidden />
-        <Button type="submit">Send</Button>
-      </Flex>
-    </Flex>
+    <View padding="large" flex="1">
+      <AIConversation
+        messages={[]}
+        handleSendMessage={handleSendMessage}
+        isLoading={isNavigating}
+      />
+    </View>
   );
 }


### PR DESCRIPTION
Style the main app page to be consistent with /chat page.
Resolve Github issue #17 where initial message gets chopped on redirect.

*Issue #17*

*Description of changes:*

Home Page (page.tsx):

Update the main page to use consistent styling with the chat page

- Uses AIConversation for consistent UI
- Stores initial message in sessionStorage
- Defers message sending to chat page
- Proper navigation handling

Chat Component (Chat.tsx):

Handle the navigation and message sending sequence properly

- Added initial message handling from sessionStorage
- Prevents duplicate message sending
- Better state management for initial message
- Maintains consistent styling with View container

The solution uses sessionStorage to safely pass the initial message between pages, ensuring the chat page is fully rendered before sending the first message. This should resolve both the styling inconsistencies and the message streaming issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
